### PR TITLE
Fix VCF parsing of files output by GATK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
+  - nightly
 notifications:
-  email: false
+  email:
+      - ward9250@gmail.com
 after_success:
   - julia -e 'using Pkg; Pkg.add("Documenter"); Pkg.add("Coverage")'
   - julia -e 'using Coverage; import GeneticVariation; cd(dirname(dirname(pathof(GeneticVariation)))); Codecov.submit(process_folder())'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- :arrow_up: Support for julia v1.0
+
+### Changed
+- Fixed an issue with parsing VCF files from recent GATK releases.
+
+### Removed
+- :exclamation: Dropped support for julia v0.6 and v0.7
 
 ## [0.3.2] - 2018-07-25
 ### Added
@@ -16,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.3.1] - 2017-10-10
 ### Added
-- Method computing the average number of mutations, that should hav gone into
+- Method computing the average number of mutations, that should have gone into
   version 0.3.0.
 
 ## [0.3.0] - 2017-10-05

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Install GeneticVariation from the Julia REPL:
 ```julia
 using Pkg
 add("GeneticVariation")
-# Pkg.add("GeneticVariation") for julia prior to v0.7
 ```
 
 If you are interested in the cutting edge of the development, please check out
@@ -32,12 +31,12 @@ the master branch to try new features before release.
 
 ## Testing
 
-GeneticVariation is tested against julia `0.6` and `0.7-dev` on Linux, OS X,
+GeneticVariation is tested against julia `1.X.Y` on Linux, OS X,
 and Windows.
 
 | **PackageEvaluator** | **Latest Build Status** |
 |:--------------------:|:-----------------------:|
-| [![](http://pkg.julialang.org/badges/GeneticVariation_0.7.svg)](http://pkg.julialang.org/?pkg=GeneticVariation) [![](http://pkg.julialang.org/badges/GeneticVariation_1.0.svg)](http://pkg.julialang.org/?pkg=GeneticVriation) |  [![](https://travis-ci.org/BioJulia/GeneticVariation.jl.svg?branch=master)](https://travis-ci.org/BioJulia/GeneticVariation.jl) [![](https://ci.appveyor.com/api/projects/status/29um8ekg6en3s23a?svg=true)](https://ci.appveyor.com/project/Ward9250/geneticvariation-jl) [![](https://codecov.io/gh/BioJulia/GeneticVariation.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/BioJulia/GeneticVariation.jl)
+|  [![](http://pkg.julialang.org/badges/GeneticVariation_1.0.svg)](http://pkg.julialang.org/?pkg=GeneticVriation) |  [![](https://travis-ci.org/BioJulia/GeneticVariation.jl.svg?branch=master)](https://travis-ci.org/BioJulia/GeneticVariation.jl) [![](https://ci.appveyor.com/api/projects/status/29um8ekg6en3s23a?svg=true)](https://ci.appveyor.com/project/Ward9250/geneticvariation-jl) [![](https://codecov.io/gh/BioJulia/GeneticVariation.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/BioJulia/GeneticVariation.jl)
 
 
 ## Contributing

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
-julia 0.7
+julia 1.0
 Automa 0.7
 BGZFStreams
-BioCore 1.1.0
+BioCore 2.0.5
 BioSequences 0.8.0
 BufferedStreams
 Combinatorics

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1
   - julia_version: nightly
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,18 @@
 environment:
   matrix:
-  - Julia_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
-  - Julia_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+matrix:
+  allow_failures:
+  - julia_version: nightly
 
 branches:
   only:
@@ -15,24 +26,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# if there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"GeneticVariation\"); Pkg.build(\"GeneticVariation\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"GeneticVariation\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
   - julia_version: nightly
 
 platform:
-  - x86 # 32-bit
   - x64 # 64-bit
 
 # # Uncomment the following lines to allow failures on nightly julia

--- a/docs/src/man/io/vcf-bcf.md
+++ b/docs/src/man/io/vcf-bcf.md
@@ -29,7 +29,7 @@ GeneticVariation.VCF.Header:
   metainfo tags: fileformat fileDate source reference contig phasing INFO FILTER FORMAT
      sample IDs: NA00001 NA00002 NA00003
 
-julia> find(header(reader), "FORMAT")
+julia> findall(header(reader), "FORMAT")
 4-element Array{GeneticVariation.VCF.MetaInfo,1}:
  GeneticVariation.VCF.MetaInfo:
     tag: FORMAT

--- a/src/GeneticVariation.jl
+++ b/src/GeneticVariation.jl
@@ -43,7 +43,6 @@ export
     isfilled,
     MissingFieldException
 
-importall BioCore
 import BioSequences:
     BioSequences,
     Alphabet,
@@ -63,8 +62,12 @@ import BioSequences:
     Position,
     RNAAlphabet,
     Sequence
+    
+import BioCore:
+    metainfotag,
+    metainfoval,
+    header
 
-import Compat: @compat
 import Combinatorics.permutations
 import IntervalTrees: Interval, IntervalValue
 import Twiddle:

--- a/src/allele_freq.jl
+++ b/src/allele_freq.jl
@@ -28,7 +28,7 @@ Compute the gene frequencies for any iterable with an `eltype` which is a
 concrete subtype of the abstract `Sequence` type.
 """
 function gene_frequencies(iterable)
-    return _gene_frequencies(iterable, eltype(iterable), Base.iteratorsize(iterable))
+    return _gene_frequencies(iterable, eltype(iterable), Base.IteratorSize(iterable))
 end
 
 # Default for most iterables, throws an error.

--- a/src/diversity_measures.jl
+++ b/src/diversity_measures.jl
@@ -24,7 +24,7 @@ in the population.
 """
 function NL79(m::AbstractMatrix{Float64}, f::AbstractVector{Float64})
     π = 0.0
-    @inbounds for i = 1:endof(f), j = (i + 1):endof(f)
+    @inbounds for i = 1:lastindex(f), j = (i + 1):lastindex(f)
         π += m[i, j] * f[i] * f[j]
     end
     return 2 * π
@@ -98,7 +98,7 @@ function avg_mut(sequences)
     n = 0
     @inbounds for i in eachindex(sequences)
         si = sequences[i]
-        for j in (i + 1):endof(sequences)
+        for j in (i + 1):lastindex(sequences)
             nmut += count(Mutated, si, sequences[j])[1]
             n += 1
         end

--- a/src/seg_sites.jl
+++ b/src/seg_sites.jl
@@ -22,9 +22,9 @@ function Base.count(::Type{Segregating}, seqs::Vector{T}) where T <: Sequence
     while cont
         i += 1
         @inbounds refelem = refseq[i]
-        @inbounds for j in 2:endof(seqs)
+        @inbounds for j in 2:lastindex(seqs)
             seq = seqs[j]
-            cont = ifelse(endof(seq) == i, false, true)
+            cont = ifelse(lastindex(seq) == i, false, true)
             if refelem != seq[i]
                 count += 1
                 break

--- a/src/vcf/header.jl
+++ b/src/vcf/header.jl
@@ -39,6 +39,11 @@ function Base.length(header::Header)
     return length(header.metainfo)
 end
 
+function Base.iterate(header::Header, i = 1)
+    return i > lastindex(header.metainfo) ? nothing : (header.metainfo[i], i + 1)
+end
+
+#=
 function Base.start(header::Header)
     return 1
 end
@@ -50,13 +55,14 @@ end
 function Base.next(header::Header, i)
     return header.metainfo[i], i + 1
 end
+=#
 
-function Base.find(header::Header, tag::AbstractString)
+function Base.findall(header::Header, tag::AbstractString)
     return Base.filter(m -> isequaltag(m, tag), header.metainfo)
 end
 
-function Base.unshift!(header::Header, metainfo)
-    unshift!(header.metainfo, convert(MetaInfo, metainfo))
+function Base.pushfirst!(header::Header, metainfo)
+    pushfirst!(header.metainfo, convert(MetaInfo, metainfo))
     return header
 end
 

--- a/src/vcf/metainfo.jl
+++ b/src/vcf/metainfo.jl
@@ -197,7 +197,7 @@ function Base.show(io::IO, metainfo::MetaInfo)
                 print(io, ' ', key, "=\"", val, '"')
             end
         else
-            print(io, ' ', metainfoval(metainfo))
+            print(io, ' ', BioCore.metainfoval(metainfo))
         end
     else
         print(io, " <not filled>")

--- a/src/vcf/metainfo.jl
+++ b/src/vcf/metainfo.jl
@@ -53,7 +53,7 @@ function MetaInfo(str::AbstractString)
 end
 
 function Base.convert(::Type{MetaInfo}, str::AbstractString)
-    return MetaInfo(convert(Vector{UInt8}, str))
+    return MetaInfo(Vector{UInt8}(str))
 end
 
 function initialize!(metainfo::MetaInfo)
@@ -90,7 +90,7 @@ function checkfilled(metainfo::MetaInfo)
     end
 end
 
-function MetaInfo(base::MetaInfo; tag=nothing, value=nothing)
+function MetaInfo(base::MetaInfo; tag = nothing, value = nothing)
     checkfilled(base)
     buf = IOBuffer()
     print(buf, "##")
@@ -104,7 +104,7 @@ function MetaInfo(base::MetaInfo; tag=nothing, value=nothing)
         write(buf, base.data[base.val])
     elseif isa(value, String)
         print(buf, value)
-    elseif isa(value, Associative) || isa(value, Vector)
+    elseif isa(value, AbstractDict) || isa(value, Vector)
         print(buf, '<')
         for (i, (key, val)) in enumerate(value)
             if i != 1
@@ -123,7 +123,7 @@ function MetaInfo(base::MetaInfo; tag=nothing, value=nothing)
 end
 
 function needs_quote(val::String)
-    return contains(val, " ") || contains(val, ",") || contains(val, "\"") || contains(val, "\\")
+    return occursin(" ", val) || occursin(",", val) || occursin("\"", val) || occursin("\\", val)
 end
 
 function isequaltag(metainfo::MetaInfo, tag::AbstractString)

--- a/src/vcf/reader.jl
+++ b/src/vcf/reader.jl
@@ -74,7 +74,7 @@ const vcf_metainfo_machine, vcf_record_machine, vcf_header_machine, vcf_body_mac
 
     # All kinds of meta-information line after 'fileformat' are handled here.
     metainfo = let
-        tag = re"[0-9A-Za-z_]+"
+        tag = re"[0-9A-Za-z_\.]+"
         tag.actions[:enter] = [:mark1]
         tag.actions[:exit]  = [:metainfo_tag]
 

--- a/src/vcf/reader.jl
+++ b/src/vcf/reader.jl
@@ -49,7 +49,7 @@ function BioCore.header(reader::Reader)
 end
 
 # VCF v4.3
-Base.info("Compiling VCF parser...")
+@info "Compiling VCF parser..."
 const vcf_metainfo_machine, vcf_record_machine, vcf_header_machine, vcf_body_machine = (function ()
     cat = Automa.RegExp.cat
     rep = Automa.RegExp.rep
@@ -219,13 +219,13 @@ const vcf_metainfo_machine, vcf_record_machine, vcf_header_machine, vcf_body_mac
 end)()
 
 const vcf_metainfo_actions = Dict(
-    :metainfo_tag      => :(record.tag = (mark1:p-1) - offset),
-    :metainfo_val      => :(record.val = (mark2:p-1) - offset; record.dict = data[mark2] == UInt8('<')),
-    :metainfo_dict_key => :(push!(record.dictkey, (mark1:p-1) - offset)),
-    :metainfo_dict_val => :(push!(record.dictval, (mark1:p-1) - offset)),
+    :metainfo_tag      => :(record.tag = (mark1:p-1) .- offset),
+    :metainfo_val      => :(record.val = (mark2:p-1) .- offset; record.dict = data[mark2] == UInt8('<')),
+    :metainfo_dict_key => :(push!(record.dictkey, (mark1:p-1) .- offset)),
+    :metainfo_dict_val => :(push!(record.dictval, (mark1:p-1) .- offset)),
     :metainfo          => quote
         BioCore.ReaderHelper.resize_and_copy!(record.data, data, offset+1:p-1)
-        record.filled = (offset+1:p-1) - offset
+        record.filled = (offset+1:p-1) .- offset
     end,
     :anchor            => :(),
     :mark1             => :(mark1 = p),
@@ -245,7 +245,7 @@ eval(
         merge(vcf_metainfo_actions, Dict(
             :metainfo => quote
                 BioCore.ReaderHelper.resize_and_copy!(record.data, data, BioCore.ReaderHelper.upanchor!(stream):p-1)
-                record.filled = (offset+1:p-1) - offset
+                record.filled = (offset+1:p-1) .- offset
                 @assert isfilled(record)
                 push!(reader.header.metainfo, record)
                 BioCore.ReaderHelper.ensure_margin!(stream)
@@ -257,20 +257,20 @@ eval(
             :anchor    => :(BioCore.ReaderHelper.anchor!(stream, p); offset = p - 1)))))
 
 const vcf_record_actions = Dict(
-    :record_chrom        => :(record.chrom = (mark:p-1) - offset),
-    :record_pos          => :(record.pos = (mark:p-1) - offset),
-    :record_id           => :(push!(record.id, (mark:p-1) - offset)),
-    :record_ref          => :(record.ref = (mark:p-1) - offset),
-    :record_alt          => :(push!(record.alt, (mark:p-1) - offset)),
-    :record_qual         => :(record.qual = (mark:p-1) - offset),
-    :record_filter       => :(push!(record.filter, (mark:p-1) - offset)),
-    :record_info_key     => :(push!(record.infokey, (mark:p-1) - offset)),
-    :record_format       => :(push!(record.format, (mark:p-1) - offset)),
+    :record_chrom        => :(record.chrom = (mark:p-1) .- offset),
+    :record_pos          => :(record.pos = (mark:p-1) .- offset),
+    :record_id           => :(push!(record.id, (mark:p-1) .- offset)),
+    :record_ref          => :(record.ref = (mark:p-1) .- offset),
+    :record_alt          => :(push!(record.alt, (mark:p-1) .- offset)),
+    :record_qual         => :(record.qual = (mark:p-1) .- offset),
+    :record_filter       => :(push!(record.filter, (mark:p-1) .- offset)),
+    :record_info_key     => :(push!(record.infokey, (mark:p-1) .- offset)),
+    :record_format       => :(push!(record.format, (mark:p-1) .- offset)),
     :record_genotype     => :(push!(record.genotype, UnitRange{Int}[])),
-    :record_genotype_elm => :(push!(record.genotype[end], (mark:p-1) - offset)),
+    :record_genotype_elm => :(push!(record.genotype[end], (mark:p-1) .- offset)),
     :record              => quote
         BioCore.ReaderHelper.resize_and_copy!(record.data, data, 1:p-1)
-        record.filled = (offset+1:p-1) - offset
+        record.filled = (offset+1:p-1) .- offset
     end,
     :anchor              => :(),
     :mark                => :(mark = p))
@@ -288,7 +288,7 @@ eval(
         merge(vcf_record_actions, Dict(
             :record    => quote
                 BioCore.ReaderHelper.resize_and_copy!(record.data, data, BioCore.ReaderHelper.upanchor!(stream):p-1)
-                record.filled = (offset+1:p-1) - offset
+                record.filled = (offset+1:p-1) .- offset
                 found_record = true
                 @escape
             end,

--- a/src/vcf/vcf.jl
+++ b/src/vcf/vcf.jl
@@ -1,5 +1,5 @@
 # vcf.jl
-# ===================
+# ======
 #
 # A submodule for reading, writing, and working with VCF formatted files.
 #

--- a/test/allele_freq.jl
+++ b/test/allele_freq.jl
@@ -11,10 +11,10 @@
 
         function test_gene_frequencies(genes, answer, seqtype)
             test_genes = convert(Vector{seqtype}, sequences)
-            test_answer = convert(Dict{seqtype, Float64}, answer)
+            test_answer = Dict{seqtype, Float64}(convert(seqtype, key) => val for (key, val) in answer)
             @test gene_frequencies(test_genes) == test_answer
             @test GeneticVariation._gene_frequencies(test_genes, seqtype, Base.SizeUnknown()) == test_answer
-            @test GeneticVariation._gene_frequencies(test_genes, seqtype, Base.HasShape()) == test_answer
+            @test GeneticVariation._gene_frequencies(test_genes, seqtype, Base.HasShape{1}()) == test_answer
         end
 
         for n in (2, 4)

--- a/test/bcf.jl
+++ b/test/bcf.jl
@@ -1,7 +1,7 @@
 @testset "BCF" begin
     record = BCF.Record()
     @test !isfilled(record)
-    @test ismatch(r"^GeneticVariation.BCF.Record: <not filled>", repr(record))
+    @test occursin(r"^GeneticVariation.BCF.Record: <not filled>", repr(record))
     @test_throws ArgumentError BCF.chrom(record)
 
     record = BCF.Record()
@@ -9,7 +9,7 @@
     record.indivlen = 0x00
     # generated from bcftools 1.3.1 (htslib 1.3.1)
     record.data = parsehex("00 00 00 00 ff ff ff ff 01 00 00 00 01 00 80 7f 00 00 01 00 00 00 00 00 07 17 2e 00")
-    record.filled = 1:endof(record.data)
+    record.filled = 1:lastindex(record.data)
     @test BCF.chrom(record) == 1
     record = BCF.Record(record)
     @test isa(record, BCF.Record)
@@ -25,7 +25,7 @@
     @test BCF.ref(record) == "AT"
     record = BCF.Record(record, alt=["ATT", "ACT"])
     @test BCF.alt(record) == ["ATT", "ACT"]
-    record = BCF.Record(record, filter=[2, 3])
+    record = BCF.Record(record, filter = [2, 3])
     @test BCF.filter(record) == [2, 3]
     record = BCF.Record(record, info=Dict(1 => Int8[42]))
     @test BCF.info(record) == [(1, 42)]
@@ -36,9 +36,9 @@
     bcfdir = joinpath(fmtdir, "BCF")
     reader = BCF.Reader(open(joinpath(bcfdir, "example.bcf")))
     let header = header(reader)
-        @test length(find(header, "fileformat")) == 1
-        @test find(header, "fileformat")[1] == VCF.MetaInfo("##fileformat=VCFv4.2")
-        @test length(find(header, "FORMAT")) == 4
+        @test length(findall(header, "fileformat")) == 1
+        @test findall(header, "fileformat")[1] == VCF.MetaInfo("##fileformat=VCFv4.2")
+        @test length(findall(header, "FORMAT")) == 4
     end
     record = BCF.Record()
     @test read!(reader, record) === record
@@ -58,7 +58,7 @@
     @test BCF.genotype(record, 1, 10) == [48]
     @test BCF.genotype(record, 2, 9) == [4,3]
     @test BCF.genotype(record, :, 9) == [[2,3],[4,3],[4,4]]
-    @test ismatch(r"^GeneticVariation.BCF.Record:\n.*", repr(record))
+    @test occursin(r"^GeneticVariation.BCF.Record:\n.*", repr(record))
     close(reader)
 
     # round-trip test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,12 @@
 module TestGeneticVariation
 
-using Base.Test
+using Test
 
 import BioCore.Testing:
     get_bio_fmt_specimens,
     random_seq,
     random_interval
+import BioCore.Exceptions.MissingFieldException
 using BioSequences, GeneticVariation
 import BufferedStreams: BufferedInputStream
 import IntervalTrees: IntervalValue
@@ -13,7 +14,7 @@ import YAML
 
 function random_seq(::Type{A}, n::Integer) where A <: Alphabet
     nts = alphabet(A)
-    probs = Vector{Float64}(length(nts))
+    probs = Vector{Float64}(undef, length(nts))
     fill!(probs, 1 / length(nts))
     return BioSequence{A}(random_seq(n, nts, probs))
 end

--- a/test/site_counting.jl
+++ b/test/site_counting.jl
@@ -49,14 +49,14 @@
         end
         @inline function testcount2(::Type{P}, a::BioSequence, b::BioSequence) where P <: BioSequences.Position
             k = 0
-            @inbounds for idx in 1:min(endof(a), endof(b))
+            @inbounds for idx in 1:min(lastindex(a), lastindex(b))
                 k += issite(P, a, b, idx)
             end
             return k
         end
         @inline function testcount(::Type{P}, a::BioSequence, b::BioSequence) where P <: BioSequences.Position
             k, c = 0, 0
-            @inbounds for idx in 1:min(endof(a), endof(b))
+            @inbounds for idx in 1:min(lastindex(a), lastindex(b))
                 isvalid = !(isgap(a[idx]) || isgap(b[idx])) && !(isambiguous(a[idx]) || isambiguous(b[idx]))
                 k += issite(P, a, b, idx) && isvalid
                 c += isvalid


### PR DESCRIPTION
## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [ ] :sparkles: New feature (A non-breaking change which adds functionality).
* [X] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [X] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :clipboard: Additional detail

According to issue #18, VCF parsing fails when the input is a VCF file from a newer version of GATK.
This PR will also end support for julia 0.7, and will only support Julia v1.0 and upwards as requested by #20.

Closes #18 
Closes #20 

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [x] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [x] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [x] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [x] :thought_balloon: I have commented liberally for any complex pieces of internal code.
